### PR TITLE
Update moleculer-web to master branch

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "moleculer-repl": "^0.5.0"
   },
   "dependencies": {
-    "moleculer-web": "^0.8.0",
+    "moleculer-web": "github:moleculerjs/moleculer-web",
     "moleculer": "^0.13.0"
   },
   "engines": {


### PR DESCRIPTION
I've tried to solve the https://github.com/moleculerjs/moleculer-web/issues/62 issue. This PR updates your moleculer-web to the `master` branch and you can try it.